### PR TITLE
修正蓝牙 UID 绕过：补齐自动探测、校验与内核能力判断

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
    - 模块已在 `tproxy.conf` 中预置 `BYPASS_APPS_LIST`，绕过 `com.sec.imsservice`、`com.sec.epdg`、拨号与通话 UI 等系统应用，以降低 VoLTE/来电异常风险。  
    - 如果你不是三星设备，可按需删减该列表。  
    - 若仍有待机耗电或唤醒锁异常，可继续尝试 `PROXY_IPV6=0` 或 `DNS_HIJACK_ENABLE=0`。
+   - 新增 `BLUETOOTH_BYPASS_ENABLE=1`（默认开启），可让蓝牙系统 UID（默认 1002）绕过代理，缓解 `hal_Bluetooth_lock` / `898000.qcom,qup_uart` 持续唤醒。
+   - `1002` 来自 Android AOSP 的 `AID_BLUETOOTH` 约定；若厂商ROM有改动，可将 `BLUETOOTH_UID=auto` 自动探测。
 
 ---
 

--- a/Scripts/tproxy.conf
+++ b/Scripts/tproxy.conf
@@ -31,6 +31,13 @@ PROXY_USB=0
 PROXY_IPV6=1
 
 
+
+# 蓝牙系统栈绕过代理（用于缓解 hal_Bluetooth_lock / qup_uart 长时间唤醒）
+# Android AOSP 中 AID_BLUETOOTH 通常为 1002；
+# 如厂商ROM改过映射，可改为 auto 自动探测 /system/etc/passwd
+BLUETOOTH_BYPASS_ENABLE=1
+BLUETOOTH_UID=1002
+
 # OneUI / 三星设备建议：启用按应用绕过，避免 IMS/通话/短信被代理导致 VoLTE 异常
 APP_PROXY_ENABLE=1
 APP_PROXY_MODE=blacklist

--- a/Scripts/tproxy.sh
+++ b/Scripts/tproxy.sh
@@ -74,6 +74,12 @@ readonly DEFAULT_BYPASS_APPS_LIST=""
 readonly DEFAULT_APP_PROXY_MODE="blacklist"
 # "blacklist" or "whitelist"
 
+# Bluetooth stack bypass (AID_BLUETOOTH=1002)
+# When enabled, traffic from Bluetooth UID will bypass proxy rules.
+readonly DEFAULT_BLUETOOTH_BYPASS_ENABLE=1
+readonly DEFAULT_BLUETOOTH_UID=1002
+readonly DEFAULT_BLUETOOTH_UID_AUTO=0
+
 # CN IP bypass configuration
 readonly DEFAULT_BYPASS_CN_IP=0
 # CN IP list file name
@@ -197,6 +203,8 @@ load_config() {
     PROXY_APPS_LIST="${PROXY_APPS_LIST:-$DEFAULT_PROXY_APPS_LIST}"
     BYPASS_APPS_LIST="${BYPASS_APPS_LIST:-$DEFAULT_BYPASS_APPS_LIST}"
     APP_PROXY_MODE="${APP_PROXY_MODE:-$DEFAULT_APP_PROXY_MODE}"
+    BLUETOOTH_BYPASS_ENABLE="${BLUETOOTH_BYPASS_ENABLE:-$DEFAULT_BLUETOOTH_BYPASS_ENABLE}"
+    BLUETOOTH_UID="${BLUETOOTH_UID:-$DEFAULT_BLUETOOTH_UID}"
     BYPASS_CN_IP="${BYPASS_CN_IP:-$DEFAULT_BYPASS_CN_IP}"
     CN_IP_FILE="${CN_IP_FILE:-$DEFAULT_CN_IP_FILE}"
     CN_IPV6_FILE="${CN_IPV6_FILE:-$DEFAULT_CN_IPV6_FILE}"
@@ -243,6 +251,8 @@ load_config() {
         log Debug "PROXY_APPS_LIST: $PROXY_APPS_LIST"
         log Debug "BYPASS_APPS_LIST: $BYPASS_APPS_LIST"
         log Debug "APP_PROXY_MODE: $APP_PROXY_MODE"
+        log Debug "BLUETOOTH_BYPASS_ENABLE: $BLUETOOTH_BYPASS_ENABLE"
+        log Debug "BLUETOOTH_UID: $BLUETOOTH_UID"
         log Debug "BYPASS_CN_IP: $BYPASS_CN_IP"
         log Debug "CN_IP_FILE: $CN_IP_FILE"
         log Debug "CN_IPV6_FILE: $CN_IPV6_FILE"
@@ -339,6 +349,24 @@ init_kernel_config_cache() {
     fi
 }
 
+resolve_bluetooth_uid() {
+    local uid_line
+
+    uid_line=$(awk -F: '/^bluetooth:/ {print $3; exit}' /system/etc/passwd 2> /dev/null || true)
+    if [ -n "$uid_line" ] && echo "$uid_line" | grep -E '^[0-9]+$' > /dev/null; then
+        echo "$uid_line"
+        return 0
+    fi
+
+    uid_line=$(awk -F: '/^bluetooth:/ {print $3; exit}' /vendor/etc/passwd 2> /dev/null || true)
+    if [ -n "$uid_line" ] && echo "$uid_line" | grep -E '^[0-9]+$' > /dev/null; then
+        echo "$uid_line"
+        return 0
+    fi
+
+    return 1
+}
+
 validate_config() {
     log Debug "Validating configuration..."
 
@@ -394,6 +422,27 @@ validate_config() {
         log Warn "Empty user or group detected, Using default user:group 'root:net_admin'"
         CORE_USER="root"
         CORE_GROUP="net_admin"
+    fi
+
+    if ! echo "$BLUETOOTH_BYPASS_ENABLE" | grep -E '^[0-1]$' > /dev/null; then
+        log Error "Invalid BLUETOOTH_BYPASS_ENABLE: $BLUETOOTH_BYPASS_ENABLE (must be 0 or 1)"
+        return 1
+    fi
+
+    if [ "$BLUETOOTH_UID" = "auto" ] || [ "$BLUETOOTH_UID" = "AUTO" ]; then
+        if BLUETOOTH_UID=$(resolve_bluetooth_uid); then
+            BLUETOOTH_UID_AUTO=1
+            log Info "Auto detected bluetooth UID: $BLUETOOTH_UID"
+        else
+            BLUETOOTH_UID="$DEFAULT_BLUETOOTH_UID"
+            BLUETOOTH_UID_AUTO=0
+            log Warn "Failed to auto detect bluetooth UID, fallback to default UID: $BLUETOOTH_UID"
+        fi
+    fi
+
+    if ! echo "$BLUETOOTH_UID" | grep -E '^[0-9]+$' > /dev/null; then
+        log Error "Invalid BLUETOOTH_UID: $BLUETOOTH_UID"
+        return 1
     fi
 
     case "$APP_PROXY_MODE" in
@@ -1107,6 +1156,20 @@ setup_proxy_chain() {
 
     local uids
     local uid
+
+    if [ "$BLUETOOTH_BYPASS_ENABLE" -eq 1 ]; then
+        if check_kernel_feature "NETFILTER_XT_MATCH_OWNER"; then
+            $cmd -t "$table" -A "APP_CHAIN$suffix" -m owner --uid-owner "$BLUETOOTH_UID" -j ACCEPT
+            if [ "$BLUETOOTH_UID_AUTO" -eq 1 ]; then
+                log Info "Added Bluetooth UID bypass (auto detected UID: $BLUETOOTH_UID)"
+            else
+                log Info "Added Bluetooth UID bypass (configured UID: $BLUETOOTH_UID)"
+            fi
+        else
+            log Warn "Bluetooth UID bypass requires NETFILTER_XT_MATCH_OWNER kernel feature"
+        fi
+    fi
+
     if [ "$APP_PROXY_ENABLE" -eq 1 ]; then
         if check_kernel_feature "NETFILTER_XT_MATCH_OWNER"; then
             log Info "Setting up application filter rules in $APP_PROXY_MODE mode"

--- a/docs/Samsung-OneUI-代理兼容性调研.md
+++ b/docs/Samsung-OneUI-代理兼容性调研.md
@@ -38,3 +38,30 @@
   1. 先关闭 IPv6 代理（`PROXY_IPV6=0`）再观察 24h。
   2. 再尝试关闭 DNS 劫持（`DNS_HIJACK_ENABLE=0`）做 A/B 对照。
   3. 保持代理核心与规则不变，仅改 1 个变量，方便定位。
+
+
+## 本次新增结论：蓝牙唤醒锁（`hal_Bluetooth_lock` / `898000.qcom,qup_uart`）
+
+### 线上资料结论（截至本次调研）
+- 社区（XDA/Pixel 社区/Reddit）存在大量同类现象报告，但**没有一个稳定、通用、且无需改内核/厂商蓝牙栈的“直接一键修复”方案**。
+- 现有“有效案例”大多是：
+  1. 关闭特定蓝牙外设特性（高频心跳/通知同步）；
+  2. 避免代理链路干预蓝牙相关网络流量；
+  3. 在系统层做更细粒度绕过后功耗恢复。
+
+### 对本模块可落地的措施
+1. 增加 `BLUETOOTH_BYPASS_ENABLE`（默认开）与 `BLUETOOTH_UID`：
+   - 默认值 `1002`，来源于 AOSP 的 `AID_BLUETOOTH`；
+   - 支持 `BLUETOOTH_UID=auto`，脚本会从 `/system/etc/passwd` 或 `/vendor/etc/passwd` 自动探测蓝牙 UID；
+   - 让 Android 蓝牙系统 UID（`AID_BLUETOOTH`）流量在 OUTPUT 侧直接 bypass，避免进入代理链。
+2. 与既有 OneUI 方案叠加：
+   - 保留 IMS/电话/短信相关包名绕过；
+   - 若仍异常，继续做单变量 A/B：`PROXY_IPV6=0`、`DNS_HIJACK_ENABLE=0`。
+
+### 资料来源（用于确认“暂无直接通用修复”）
+- XDA 讨论：`hal_bluetooth_lock` 长时间唤醒（机型/ROM相关，缺乏统一修复）
+  - <https://xdaforums.com/t/hal_bluetooth_lock-wakelock.3753994/>
+- Google Pixel 社区：`hal_bluetooth_lock active 100%` 反馈
+  - <https://support.google.com/pixelphone/thread/235709034/hal-bluetooth-lock-active-100-of-the-time-on-pixel-7a>
+- 社区聚合讨论：`qup_uart` 与蓝牙并发时待机耗电
+  - <https://xdaforums.com/tags/qup_uart/>


### PR DESCRIPTION
### Motivation
- 之前的改动仅新增配置变量，需确认脚本能真正下发并兼容不同 ROM 的蓝牙 UID 映射以避免“只加变量”的空实现。 
- 需要说明并固化 `1002` 的来源，并在可能的情况下支持自动探测以兼容厂商改动。

### Description
- 在 `Scripts/tproxy.sh` 中新增 `resolve_bluetooth_uid()`，支持从 `/system/etc/passwd` 与 `/vendor/etc/passwd` 自动探测 `bluetooth` 用户的 UID，并增加 `DEFAULT_BLUETOOTH_UID_AUTO` 变量用于标记自动探测状态。 
- 在配置加载处加载 `BLUETOOTH_BYPASS_ENABLE` 与 `BLUETOOTH_UID`，并在 `validate_config()` 中新增对 `BLUETOOTH_BYPASS_ENABLE` 与 `BLUETOOTH_UID`（支持 `auto`）的合法性校验与自动探测回退逻辑。 
- 在下发 APP_CHAIN 的蓝牙绕过规则前增加内核能力判断 `NETFILTER_XT_MATCH_OWNER`，仅在支持时使用 `-m owner --uid-owner <UID> -j ACCEPT`，否则输出警告以避免下发无效规则。 
- 更新 `Scripts/tproxy.conf`、`README.md` 与 `docs/Samsung-OneUI-代理兼容性调研.md`，在配置与文档中注明 `1002` 来源于 AOSP 的 `AID_BLUETOOTH` 约定并支持 `BLUETOOTH_UID=auto` 自动探测说明与使用提示。 

### Testing
- 运行语法检查 `bash -n Scripts/tproxy.sh`，结果通过。 
- 使用 `rg` 检查新增标识与函数（如 `BLUETOOTH_UID_AUTO`、`resolve_bluetooth_uid`、`BLUETOOTH_BYPASS_ENABLE`、`BLUETOOTH_UID=auto`、`NETFILTER_XT_MATCH_OWNER`）已落地，检查通过。 
- 验证 `tproxy.conf` 与文档中已添加关于 `1002` 来源与 `auto` 探测的说明，文本检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699882b6d4e48329a31aadcd0ad76b88)